### PR TITLE
[BUG] 카카오 SDK 난독화 설정 및 구글 & 네이버 아이콘 비활성화

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -43,3 +43,4 @@
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;
 }
+-keep class com.kakao.sdk.**.model.* { <fields>; }

--- a/app/src/main/res/layout/activity_social_login.xml
+++ b/app/src/main/res/layout/activity_social_login.xml
@@ -51,6 +51,7 @@
                     android:text="@string/google_login"
                     android:textAlignment="textStart"
                     android:textColor="@color/black"
+                    android:visibility="gone"
                     app:layout_constraintBottom_toTopOf="@+id/button_naver_login"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />
@@ -67,6 +68,7 @@
                     android:text="@string/naver_login"
                     android:textAlignment="textStart"
                     android:textColor="@color/white"
+                    android:visibility="gone"
                     app:layout_constraintBottom_toTopOf="@+id/button_kakao_login"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />


### PR DESCRIPTION
## PR 개요

- #145 

### 작업사항의 상세한 설명
- 카카오 SDK 난독화 추가
- 다른 소셜 아이콘 비활성화


## 추가내용



- [ ] Added Reviewers, Assignees, Labels, Milestone
